### PR TITLE
Add support for additional Open Graph meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ The `SeoHelper`-class exposes multiple properties to get or set multiple SEO-rel
 - `MetaDescription`: Gets or sets the meta-description for web-page.
 - `MetaKeywords`: Gets or sets the meta-keywords for web-page.
 - `MetaRobots`: Gets or sets meta-robots instructions web-page.
+- `OgAudio`: Gets or sets the open graph audio URL for web-page.
 - `OgDescription`: Gets or sets the open graph description for web-page.
 Falls back on value in `MetaDescription`.
+- `OgDeterminer`: Gets or sets the open graph determiner for web-page.
 - `OgImage`: Gets or sets the open graph image for web-page.
+- `OgLocale`: Gets or sets the open graph locale for web-page.
+- `OgLocaleAlternates`: Gets or sets the open graph alternate locales for web-page.
 - `OgSiteName`: Gets or sets the open graph site-name for web-page.
 Falls back on value in `SiteName`.
 - `OgTitle`: Gets or sets the open graph title for web-page.
@@ -25,6 +29,7 @@ Falls back on value in `PageTitle`.
 - `OgType`: Gets or sets the open graph type for web-page.
 - `OgUrl`: Gets or sets the open graph URL for web-page.
 Falls back on value in `LinkCanonical`.
+- `OgVideo`: Gets or sets the open graph video URL for web-page.
 - `PageTitle`: Gets or sets the title for a web-page.
   - `SiteName`: Gets or sets the name for the web-site. Used as base for `DocumentTitle`.
 

--- a/src/AspNetSeo.CoreMvc/OgAudioAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgAudioAttribute.cs
@@ -1,0 +1,17 @@
+namespace AspNetSeo.CoreMvc;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public class OgAudioAttribute : SeoAttributeBase
+{
+    private readonly string _value;
+
+    public OgAudioAttribute(string value)
+    {
+        _value = value;
+    }
+
+    public override void OnHandleSeoValues(ISeoHelper seoHelper)
+    {
+        seoHelper.OgAudio = _value;
+    }
+}

--- a/src/AspNetSeo.CoreMvc/OgDeterminerAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgDeterminerAttribute.cs
@@ -1,0 +1,17 @@
+namespace AspNetSeo.CoreMvc;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public class OgDeterminerAttribute : SeoAttributeBase
+{
+    private readonly string _value;
+
+    public OgDeterminerAttribute(string value)
+    {
+        _value = value;
+    }
+
+    public override void OnHandleSeoValues(ISeoHelper seoHelper)
+    {
+        seoHelper.OgDeterminer = _value;
+    }
+}

--- a/src/AspNetSeo.CoreMvc/OgLocaleAlternateAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgLocaleAlternateAttribute.cs
@@ -1,0 +1,20 @@
+namespace AspNetSeo.CoreMvc;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+public class OgLocaleAlternateAttribute : SeoAttributeBase
+{
+    private readonly string[] _values;
+
+    public OgLocaleAlternateAttribute(params string[] values)
+    {
+        _values = values;
+    }
+
+    public override void OnHandleSeoValues(ISeoHelper seoHelper)
+    {
+        foreach (var value in _values)
+        {
+            seoHelper.OgLocaleAlternates.Add(value);
+        }
+    }
+}

--- a/src/AspNetSeo.CoreMvc/OgLocaleAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgLocaleAttribute.cs
@@ -1,0 +1,17 @@
+namespace AspNetSeo.CoreMvc;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public class OgLocaleAttribute : SeoAttributeBase
+{
+    private readonly string _value;
+
+    public OgLocaleAttribute(string value)
+    {
+        _value = value;
+    }
+
+    public override void OnHandleSeoValues(ISeoHelper seoHelper)
+    {
+        seoHelper.OgLocale = _value;
+    }
+}

--- a/src/AspNetSeo.CoreMvc/OgVideoAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgVideoAttribute.cs
@@ -1,0 +1,17 @@
+namespace AspNetSeo.CoreMvc;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public class OgVideoAttribute : SeoAttributeBase
+{
+    private readonly string _value;
+
+    public OgVideoAttribute(string value)
+    {
+        _value = value;
+    }
+
+    public override void OnHandleSeoValues(ISeoHelper seoHelper)
+    {
+        seoHelper.OgVideo = _value;
+    }
+}

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgAudioTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgAudioTagHelper.cs
@@ -1,0 +1,23 @@
+using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.Internal;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace AspNetSeo.CoreMvc.TagHelpers;
+
+[HtmlTargetElement("og-audio", TagStructure = TagStructure.WithoutEndTag)]
+[OutputElementHint("meta")]
+public class OgAudioTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
+{
+    public string? Value { get; set; }
+
+    public override void Process(
+        TagHelperContext context,
+        TagHelperOutput output)
+    {
+        var content = TagValueUtility.GetContent(
+            Value,
+            SeoHelper.OgAudio);
+
+        output.ProcessOpenGraph(OgMetaName.Audio, content);
+    }
+}

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgDeterminerTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgDeterminerTagHelper.cs
@@ -1,0 +1,23 @@
+using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.Internal;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace AspNetSeo.CoreMvc.TagHelpers;
+
+[HtmlTargetElement("og-determiner", TagStructure = TagStructure.WithoutEndTag)]
+[OutputElementHint("meta")]
+public class OgDeterminerTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
+{
+    public string? Value { get; set; }
+
+    public override void Process(
+        TagHelperContext context,
+        TagHelperOutput output)
+    {
+        var content = TagValueUtility.GetContent(
+            Value,
+            SeoHelper.OgDeterminer);
+
+        output.ProcessOpenGraph(OgMetaName.Determiner, content);
+    }
+}

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleAlternateTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleAlternateTagHelper.cs
@@ -1,0 +1,58 @@
+using AspNetSeo.Internal;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Linq;
+
+namespace AspNetSeo.CoreMvc.TagHelpers;
+
+[HtmlTargetElement("og-locale-alternate", TagStructure = TagStructure.NormalOrSelfClosing)]
+public class OgLocaleAlternateTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
+{
+    public string? Value { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        var values = Value != null
+            ? new[] { Value }
+            : SeoHelper.OgLocaleAlternates;
+
+        if (values == null || !values.Any())
+        {
+            output.SuppressOutput();
+            return;
+        }
+
+        output.TagName = null;
+        output.Attributes.Clear();
+
+        var isFirst = true;
+        foreach (var locale in values)
+        {
+            if (string.IsNullOrWhiteSpace(locale))
+            {
+                continue;
+            }
+
+            if (!isFirst)
+            {
+                output.Content.AppendHtml(Environment.NewLine);
+            }
+
+            var tag = new TagBuilder("meta")
+            {
+                TagRenderMode = TagRenderMode.SelfClosing
+            };
+
+            tag.Attributes["property"] = OgMetaName.LocaleAlternate;
+            tag.Attributes["content"] = locale;
+
+            output.Content.AppendHtml(tag);
+            isFirst = false;
+        }
+
+        if (isFirst)
+        {
+            output.SuppressOutput();
+        }
+    }
+}

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleTagHelper.cs
@@ -1,0 +1,23 @@
+using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.Internal;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace AspNetSeo.CoreMvc.TagHelpers;
+
+[HtmlTargetElement("og-locale", TagStructure = TagStructure.WithoutEndTag)]
+[OutputElementHint("meta")]
+public class OgLocaleTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
+{
+    public string? Value { get; set; }
+
+    public override void Process(
+        TagHelperContext context,
+        TagHelperOutput output)
+    {
+        var content = TagValueUtility.GetContent(
+            Value,
+            SeoHelper.OgLocale);
+
+        output.ProcessOpenGraph(OgMetaName.Locale, content);
+    }
+}

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgVideoTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgVideoTagHelper.cs
@@ -1,0 +1,23 @@
+using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.Internal;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace AspNetSeo.CoreMvc.TagHelpers;
+
+[HtmlTargetElement("og-video", TagStructure = TagStructure.WithoutEndTag)]
+[OutputElementHint("meta")]
+public class OgVideoTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
+{
+    public string? Value { get; set; }
+
+    public override void Process(
+        TagHelperContext context,
+        TagHelperOutput output)
+    {
+        var content = TagValueUtility.GetContent(
+            Value,
+            SeoHelper.OgVideo);
+
+        output.ProcessOpenGraph(OgMetaName.Video, content);
+    }
+}

--- a/src/AspNetSeo/ISeoHelper.cs
+++ b/src/AspNetSeo/ISeoHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace AspNetSeo;
+﻿using System.Collections.Generic;
+
+namespace AspNetSeo;
 
 public interface ISeoHelper
 {
@@ -16,9 +18,17 @@ public interface ISeoHelper
 
     string? MetaRobots { get; set; }
 
+    string? OgAudio { get; set; }
+
     string? OgDescription { get; set; }
 
+    string? OgDeterminer { get; set; }
+
     string? OgImage { get; set; }
+
+    string? OgLocale { get; set; }
+
+    IList<string> OgLocaleAlternates { get; }
 
     string? OgSiteName { get; set; }
 
@@ -27,6 +37,8 @@ public interface ISeoHelper
     string? OgType { get; set; }
 
     string? OgUrl { get; set; }
+
+    string? OgVideo { get; set; }
 
     string? PageTitle { get; set; }
 

--- a/src/AspNetSeo/Internal/OgMetaName.cs
+++ b/src/AspNetSeo/Internal/OgMetaName.cs
@@ -2,9 +2,17 @@
 
 internal static class OgMetaName
 {
+    public const string Audio = "og:audio";
+
     public const string Description = "og:description";
 
+    public const string Determiner = "og:determiner";
+
     public const string Image = "og:image";
+
+    public const string Locale = "og:locale";
+
+    public const string LocaleAlternate = "og:locale:alternate";
 
     public const string SiteName = "og:site_name";
 
@@ -13,4 +21,6 @@ internal static class OgMetaName
     public const string Type = "og:type";
 
     public const string Url = "og:url";
+
+    public const string Video = "og:video";
 }

--- a/src/AspNetSeo/SeoHelper.cs
+++ b/src/AspNetSeo/SeoHelper.cs
@@ -1,4 +1,5 @@
 ﻿using AspNetSeo.Internal;
+using System.Collections.Generic;
 
 namespace AspNetSeo;
 
@@ -22,9 +23,17 @@ public class SeoHelper : ISeoHelper
 
     public string? MetaRobots { get; set; }
 
+    public string? OgAudio { get; set; }
+
     public string? OgDescription { get; set; }
 
+    public string? OgDeterminer { get; set; }
+
     public string? OgImage { get; set; }
+
+    public string? OgLocale { get; set; }
+
+    public IList<string> OgLocaleAlternates { get; } = new List<string>();
 
     public string? OgSiteName { get; set; }
 
@@ -33,6 +42,8 @@ public class SeoHelper : ISeoHelper
     public string? OgType { get; set; }
 
     public string? OgUrl { get; set; }
+
+    public string? OgVideo { get; set; }
 
     public string? PageTitle { get; set; }
 

--- a/test/AspNetSeo.CoreMvc.Tests/TagAttributeTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagAttributeTest.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+using System.Collections.Generic;
+using Xunit;
 
 namespace AspNetSeo.CoreMvc.Tests;
 
@@ -29,7 +30,7 @@ public class TagAttributeTest
             new LinkCanonicalAttribute("TEST_LINK_CANONICAL"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.LinkCanonical),
-            "TEST_LINK_CANONICAL"
+            "TEST_LINK_CANONICAL",
         };
 
         yield return new object[]
@@ -37,7 +38,7 @@ public class TagAttributeTest
             new MetaDescriptionAttribute("TEST_META_DESCRIPTION"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.MetaDescription),
-            "TEST_META_DESCRIPTION"
+            "TEST_META_DESCRIPTION",
         };
 
         yield return new object[]
@@ -45,7 +46,7 @@ public class TagAttributeTest
             new MetaKeywordsAttribute("TEST_META_KEYWORDS"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.MetaKeywords),
-            "TEST_META_KEYWORDS"
+            "TEST_META_KEYWORDS",
         };
 
         yield return new object[]
@@ -53,7 +54,7 @@ public class TagAttributeTest
             new MetaRobotsAttribute("TEST_META_ROBOTS"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.MetaRobots),
-            "TEST_META_ROBOTS"
+            "TEST_META_ROBOTS",
         };
 
         yield return new object[]
@@ -61,7 +62,7 @@ public class TagAttributeTest
             new MetaRobotsAttribute(index: true, follow: true),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.MetaRobots),
-            "INDEX, FOLLOW"
+            "INDEX, FOLLOW",
         };
 
         yield return new object[]
@@ -69,7 +70,7 @@ public class TagAttributeTest
             new MetaRobotsAttribute(index: false, follow: true),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.MetaRobots),
-            "NOINDEX, FOLLOW"
+            "NOINDEX, FOLLOW",
         };
 
         yield return new object[]
@@ -77,7 +78,7 @@ public class TagAttributeTest
             new MetaRobotsAttribute(index: true, follow: false),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.MetaRobots),
-            "INDEX, NOFOLLOW"
+            "INDEX, NOFOLLOW",
         };
 
         yield return new object[]
@@ -85,7 +86,15 @@ public class TagAttributeTest
             new MetaRobotsAttribute(index: false, follow: false),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.MetaRobots),
-            "NOINDEX, NOFOLLOW"
+            "NOINDEX, NOFOLLOW",
+        };
+
+        yield return new object[]
+        {
+            new OgAudioAttribute("TEST_OG_AUDIO"),
+            GetResultFactory(
+                (ISeoHelper seoHelper) => seoHelper.OgAudio),
+            "TEST_OG_AUDIO",
         };
 
         yield return new object[]
@@ -93,7 +102,15 @@ public class TagAttributeTest
             new OgDescriptionAttribute("TEST_OG_DESCRIPTION"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.OgDescription),
-            "TEST_OG_DESCRIPTION"
+            "TEST_OG_DESCRIPTION",
+        };
+
+        yield return new object[]
+        {
+            new OgDeterminerAttribute("TEST_OG_DETERMINER"),
+            GetResultFactory(
+                (ISeoHelper seoHelper) => seoHelper.OgDeterminer),
+            "TEST_OG_DETERMINER",
         };
 
         yield return new object[]
@@ -101,7 +118,23 @@ public class TagAttributeTest
             new OgImageAttribute("TEST_OG_IMAGE"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.OgImage),
-            "TEST_OG_IMAGE"
+            "TEST_OG_IMAGE",
+        };
+
+        yield return new object[]
+        {
+            new OgLocaleAttribute("TEST_OG_LOCALE"),
+            GetResultFactory(
+                (ISeoHelper seoHelper) => seoHelper.OgLocale),
+            "TEST_OG_LOCALE",
+        };
+
+        yield return new object[]
+        {
+            new OgLocaleAlternateAttribute("da_DK", "en_US"),
+            GetResultFactory(
+                (ISeoHelper seoHelper) => seoHelper.OgLocaleAlternates),
+            new List<string> { "da_DK", "en_US" }
         };
 
         yield return new object[]
@@ -109,7 +142,7 @@ public class TagAttributeTest
             new OgSiteNameAttribute("TEST_OG_SITE_NAME"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.OgSiteName),
-            "TEST_OG_SITE_NAME"
+            "TEST_OG_SITE_NAME",
         };
 
         yield return new object[]
@@ -117,7 +150,7 @@ public class TagAttributeTest
             new OgTitleAttribute("TEST_OG_TITLE"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.OgTitle),
-            "TEST_OG_TITLE"
+            "TEST_OG_TITLE",
         };
 
         yield return new object[]
@@ -125,7 +158,7 @@ public class TagAttributeTest
             new OgTypeAttribute("TEST_OG_TYPE"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.OgType),
-            "TEST_OG_TYPE"
+            "TEST_OG_TYPE",
         };
 
         yield return new object[]
@@ -133,7 +166,15 @@ public class TagAttributeTest
             new OgUrlAttribute("TEST_OG_URL"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.OgUrl),
-            "TEST_OG_URL"
+            "TEST_OG_URL",
+        };
+
+        yield return new object[]
+        {
+            new OgVideoAttribute("TEST_OG_VIDEO"),
+            GetResultFactory(
+                (ISeoHelper seoHelper) => seoHelper.OgVideo),
+            "TEST_OG_VIDEO",
         };
 
         yield return new object[]
@@ -141,7 +182,7 @@ public class TagAttributeTest
             new PageTitleAttribute("TEST_PAGE_TITLE"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.PageTitle),
-            "TEST_PAGE_TITLE"
+            "TEST_PAGE_TITLE",
         };
 
         yield return new object[]
@@ -149,7 +190,7 @@ public class TagAttributeTest
             new SiteNameAttribute("TEST_SITE_NAME"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.SiteName),
-            "TEST_SITE_NAME"
+            "TEST_SITE_NAME",
         };
 
         yield return new object[]
@@ -157,7 +198,7 @@ public class TagAttributeTest
             new SiteUrlAttribute("TEST_SITE_URL"),
             GetResultFactory(
                 (ISeoHelper seoHelper) => seoHelper.SiteUrl),
-            "TEST_SITE_URL"
+            "TEST_SITE_URL",
         };
     }
 

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgAudioTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgAudioTagHelperTest.cs
@@ -1,0 +1,47 @@
+using AspNetSeo.CoreMvc.TagHelpers;
+using AspNetSeo.Internal;
+using AspNetSeo.Testing;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace AspNetSeo.CoreMvc.Tests.TagHelpers;
+
+public class OgAudioTagHelperTest : TagHelperTestBase
+{
+    [Theory]
+    [MemberData(nameof(GetMemberData))]
+    public void Process_TestData_ReturnsExpectedHtml(
+        string expected,
+        TagHelper tagHelper)
+    {
+        var html = tagHelper.GetHtml("og-audio");
+        Assert.Equal(expected, html);
+    }
+
+    public static IEnumerable<object[]> GetMemberData()
+    {
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.Audio, "TEST_OG_AUDIO"),
+            TagHelperTestFactory.Create(
+                seo => new OgAudioTagHelper(seo),
+                seo => seo.OgAudio = "TEST_OG_AUDIO")
+        };
+
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.Audio, "OVERRIDE_AUDIO"),
+            TagHelperTestFactory.Create(
+                seo => new OgAudioTagHelper(seo),
+                seo => seo.OgAudio = "TEST_OG_AUDIO",
+                tag => tag.Value = "OVERRIDE_AUDIO")
+        };
+
+        yield return new object[]
+        {
+            string.Empty,
+            TagHelperTestFactory.Create(
+                seo => new OgAudioTagHelper(seo))
+        };
+    }
+}

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgDeterminerTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgDeterminerTagHelperTest.cs
@@ -1,0 +1,47 @@
+using AspNetSeo.CoreMvc.TagHelpers;
+using AspNetSeo.Internal;
+using AspNetSeo.Testing;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace AspNetSeo.CoreMvc.Tests.TagHelpers;
+
+public class OgDeterminerTagHelperTest : TagHelperTestBase
+{
+    [Theory]
+    [MemberData(nameof(GetMemberData))]
+    public void Process_TestData_ReturnsExpectedHtml(
+        string expected,
+        TagHelper tagHelper)
+    {
+        var html = tagHelper.GetHtml("og-determiner");
+        Assert.Equal(expected, html);
+    }
+
+    public static IEnumerable<object[]> GetMemberData()
+    {
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.Determiner, "the"),
+            TagHelperTestFactory.Create(
+                seo => new OgDeterminerTagHelper(seo),
+                seo => seo.OgDeterminer = "the")
+        };
+
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.Determiner, "a"),
+            TagHelperTestFactory.Create(
+                seo => new OgDeterminerTagHelper(seo),
+                seo => seo.OgDeterminer = "the",
+                tag => tag.Value = "a")
+        };
+
+        yield return new object[]
+        {
+            string.Empty,
+            TagHelperTestFactory.Create(
+                seo => new OgDeterminerTagHelper(seo))
+        };
+    }
+}

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgLocaleAlternateTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgLocaleAlternateTagHelperTest.cs
@@ -1,0 +1,48 @@
+using AspNetSeo.CoreMvc.TagHelpers;
+using AspNetSeo.Internal;
+using AspNetSeo.Testing;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace AspNetSeo.CoreMvc.Tests.TagHelpers;
+
+public class OgLocaleAlternateTagHelperTest : TagHelperTestBase
+{
+    [Theory]
+    [MemberData(nameof(GetMemberData))]
+    public void Process_TestData_ReturnsExpectedHtml(
+        string expected,
+        TagHelper tagHelper)
+    {
+        var html = tagHelper.GetHtml("og-locale-alternate");
+        Assert.Equal(expected, html);
+    }
+
+    public static IEnumerable<object[]> GetMemberData()
+    {
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.LocaleAlternate, "da_DK") + Environment.NewLine +
+            OpenGraphTag(OgMetaName.LocaleAlternate, "en_US"),
+            TagHelperTestFactory.Create(
+                seo => new OgLocaleAlternateTagHelper(seo),
+                seo => { seo.OgLocaleAlternates.Add("da_DK"); seo.OgLocaleAlternates.Add("en_US"); })
+        };
+
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.LocaleAlternate, "de_DE"),
+            TagHelperTestFactory.Create(
+                seo => new OgLocaleAlternateTagHelper(seo),
+                seo => { seo.OgLocaleAlternates.Add("da_DK"); },
+                tag => tag.Value = "de_DE")
+        };
+
+        yield return new object[]
+        {
+            string.Empty,
+            TagHelperTestFactory.Create(
+                seo => new OgLocaleAlternateTagHelper(seo))
+        };
+    }
+}

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgLocaleTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgLocaleTagHelperTest.cs
@@ -1,0 +1,47 @@
+using AspNetSeo.CoreMvc.TagHelpers;
+using AspNetSeo.Internal;
+using AspNetSeo.Testing;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace AspNetSeo.CoreMvc.Tests.TagHelpers;
+
+public class OgLocaleTagHelperTest : TagHelperTestBase
+{
+    [Theory]
+    [MemberData(nameof(GetMemberData))]
+    public void Process_TestData_ReturnsExpectedHtml(
+        string expected,
+        TagHelper tagHelper)
+    {
+        var html = tagHelper.GetHtml("og-locale");
+        Assert.Equal(expected, html);
+    }
+
+    public static IEnumerable<object[]> GetMemberData()
+    {
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.Locale, "da_DK"),
+            TagHelperTestFactory.Create(
+                seo => new OgLocaleTagHelper(seo),
+                seo => seo.OgLocale = "da_DK")
+        };
+
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.Locale, "en_US"),
+            TagHelperTestFactory.Create(
+                seo => new OgLocaleTagHelper(seo),
+                seo => seo.OgLocale = "da_DK",
+                tag => tag.Value = "en_US")
+        };
+
+        yield return new object[]
+        {
+            string.Empty,
+            TagHelperTestFactory.Create(
+                seo => new OgLocaleTagHelper(seo))
+        };
+    }
+}

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgVideoTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgVideoTagHelperTest.cs
@@ -1,0 +1,47 @@
+using AspNetSeo.CoreMvc.TagHelpers;
+using AspNetSeo.Internal;
+using AspNetSeo.Testing;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace AspNetSeo.CoreMvc.Tests.TagHelpers;
+
+public class OgVideoTagHelperTest : TagHelperTestBase
+{
+    [Theory]
+    [MemberData(nameof(GetMemberData))]
+    public void Process_TestData_ReturnsExpectedHtml(
+        string expected,
+        TagHelper tagHelper)
+    {
+        var html = tagHelper.GetHtml("og-video");
+        Assert.Equal(expected, html);
+    }
+
+    public static IEnumerable<object[]> GetMemberData()
+    {
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.Video, "TEST_OG_VIDEO"),
+            TagHelperTestFactory.Create(
+                seo => new OgVideoTagHelper(seo),
+                seo => seo.OgVideo = "TEST_OG_VIDEO")
+        };
+
+        yield return new object[]
+        {
+            OpenGraphTag(OgMetaName.Video, "OVERRIDE_VIDEO"),
+            TagHelperTestFactory.Create(
+                seo => new OgVideoTagHelper(seo),
+                seo => seo.OgVideo = "TEST_OG_VIDEO",
+                tag => tag.Value = "OVERRIDE_VIDEO")
+        };
+
+        yield return new object[]
+        {
+            string.Empty,
+            TagHelperTestFactory.Create(
+                seo => new OgVideoTagHelper(seo))
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add properties for `og:audio`, `og:determiner`, `og:locale`, `og:locale:alternate` and `og:video`
- introduce matching attributes and tag helpers with tests
- update README with new Open Graph fields

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a75a5801348323ab28bba3871efff6