### PR TITLE
Add concise XML documentation across public API

### DIFF
--- a/src/AspNetSeo.CoreMvc/ActionContextExtensions.cs
+++ b/src/AspNetSeo.CoreMvc/ActionContextExtensions.cs
@@ -1,9 +1,15 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Extension methods for <see cref="ActionContext"/>.
+/// </summary>
 public static class ActionContextExtensions
 {
+    /// <summary>Gets the registered <see cref="ISeoHelper"/>.</summary>
+    /// <param name="context">The MVC action context.</param>
+    /// <returns>The SEO helper.</returns>
     public static ISeoHelper GetSeoHelper(this ActionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -20,3 +26,4 @@ public static class ActionContextExtensions
         return seoHelper;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/ControllerBaseExtensions.cs
+++ b/src/AspNetSeo.CoreMvc/ControllerBaseExtensions.cs
@@ -1,9 +1,15 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Extensions for <see cref="ControllerBase"/>.
+/// </summary>
 public static class ControllerBaseExtensions
 {
+    /// <summary>Gets the registered <see cref="ISeoHelper"/>.</summary>
+    /// <param name="controller">The controller.</param>
+    /// <returns>The SEO helper.</returns>
     public static ISeoHelper GetSeoHelper(this ControllerBase controller)
     {
         ArgumentNullException.ThrowIfNull(controller);
@@ -20,3 +26,4 @@ public static class ControllerBaseExtensions
         return seoHelper;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/CustomMetaAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/CustomMetaAttribute.cs
@@ -1,5 +1,10 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Adds a custom meta tag.
+/// </summary>
+/// <param name="name">Meta name.</param>
+/// <param name="content">Meta content.</param>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
 public class CustomMetaAttribute(string name, string content) : SeoAttributeBase
 {
@@ -8,8 +13,11 @@ public class CustomMetaAttribute(string name, string content) : SeoAttributeBase
 
     private readonly string _content = content;
 
+    /// <summary>Applies the custom meta.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.CustomMetas[_name] = _content;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/ISeoUrlHelper.cs
+++ b/src/AspNetSeo.CoreMvc/ISeoUrlHelper.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetSeo.CoreMvc;
+
+/// <summary>
+/// URL helper used for SEO tasks.
+/// </summary>
+public interface ISeoUrlHelper : IUrlHelper
+{
+}
+

--- a/src/AspNetSeo.CoreMvc/Internal/ISeoUrlHelper.cs
+++ b/src/AspNetSeo.CoreMvc/Internal/ISeoUrlHelper.cs
@@ -1,7 +1,0 @@
-﻿using Microsoft.AspNetCore.Mvc;
-
-namespace AspNetSeo.CoreMvc.Internal;
-
-public interface ISeoUrlHelper : IUrlHelper
-{
-}

--- a/src/AspNetSeo.CoreMvc/Internal/SeoUrlHelper.cs
+++ b/src/AspNetSeo.CoreMvc/Internal/SeoUrlHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using AspNetSeo.CoreMvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
 
 namespace AspNetSeo.CoreMvc.Internal;

--- a/src/AspNetSeo.CoreMvc/LinkCanonicalAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/LinkCanonicalAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the canonical link.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class LinkCanonicalAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Canonical URL.</param>
     public LinkCanonicalAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the canonical link.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.LinkCanonical = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/MetaDescriptionAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/MetaDescriptionAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the meta description.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class MetaDescriptionAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Meta description.</param>
     public MetaDescriptionAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the description.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.MetaDescription = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/MetaKeywordsAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/MetaKeywordsAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the meta keywords.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class MetaKeywordsAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Meta keywords.</param>
     public MetaKeywordsAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the keywords.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.MetaKeywords = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/MetaRobotsAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/MetaRobotsAttribute.cs
@@ -1,24 +1,35 @@
-﻿using AspNetSeo.Internal;
+using AspNetSeo.Internal;
 
 namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the meta robots value.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class MetaRobotsAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute with a value.</summary>
+    /// <param name="value">Robots value.</param>
     public MetaRobotsAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Initializes the attribute with flags.</summary>
+    /// <param name="index">Allow indexing.</param>
+    /// <param name="follow">Allow following.</param>
     public MetaRobotsAttribute(bool index, bool follow)
     {
         _value = MetaRobotsValue.Get(index, follow);
     }
 
+    /// <summary>Applies the robots value.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.MetaRobots = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgAudioAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgAudioAttribute.cs
@@ -1,17 +1,25 @@
 ﻿namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph audio URL.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgAudioAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Audio URL.</param>
     public OgAudioAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the audio URL.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgAudio = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgAudioAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgAudioAttribute.cs
@@ -1,4 +1,4 @@
-namespace AspNetSeo.CoreMvc;
+﻿namespace AspNetSeo.CoreMvc;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgAudioAttribute : SeoAttributeBase

--- a/src/AspNetSeo.CoreMvc/OgDescriptionAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgDescriptionAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph description.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgDescriptionAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Description text.</param>
     public OgDescriptionAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the description.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgDescription = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgDeterminerAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgDeterminerAttribute.cs
@@ -1,17 +1,25 @@
 ﻿namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph determiner.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgDeterminerAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Determiner value.</param>
     public OgDeterminerAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the determiner.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgDeterminer = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgDeterminerAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgDeterminerAttribute.cs
@@ -1,4 +1,4 @@
-namespace AspNetSeo.CoreMvc;
+﻿namespace AspNetSeo.CoreMvc;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgDeterminerAttribute : SeoAttributeBase

--- a/src/AspNetSeo.CoreMvc/OgImageAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgImageAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph image URL.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgImageAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Image URL.</param>
     public OgImageAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the image URL.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgImage = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgLocaleAlternateAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgLocaleAlternateAttribute.cs
@@ -1,4 +1,4 @@
-namespace AspNetSeo.CoreMvc;
+﻿namespace AspNetSeo.CoreMvc;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
 public class OgLocaleAlternateAttribute : SeoAttributeBase

--- a/src/AspNetSeo.CoreMvc/OgLocaleAlternateAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgLocaleAlternateAttribute.cs
@@ -1,15 +1,22 @@
 ﻿namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Adds alternate Open Graph locales.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
 public class OgLocaleAlternateAttribute : SeoAttributeBase
 {
     private readonly string[] _values;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="values">Locale values.</param>
     public OgLocaleAlternateAttribute(params string[] values)
     {
         _values = values;
     }
 
+    /// <summary>Applies the locale alternates.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         foreach (var value in _values)
@@ -18,3 +25,4 @@ public class OgLocaleAlternateAttribute : SeoAttributeBase
         }
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgLocaleAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgLocaleAttribute.cs
@@ -1,17 +1,25 @@
 ﻿namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph locale.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgLocaleAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Locale value.</param>
     public OgLocaleAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the locale.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgLocale = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgLocaleAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgLocaleAttribute.cs
@@ -1,4 +1,4 @@
-namespace AspNetSeo.CoreMvc;
+﻿namespace AspNetSeo.CoreMvc;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgLocaleAttribute : SeoAttributeBase

--- a/src/AspNetSeo.CoreMvc/OgSiteNameAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgSiteNameAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph site name.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgSiteNameAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Site name.</param>
     public OgSiteNameAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the site name.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgSiteName = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgTitleAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgTitleAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph title.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgTitleAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Title value.</param>
     public OgTitleAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the title.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgTitle = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgTypeAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgTypeAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph type.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgTypeAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Type value.</param>
     public OgTypeAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the type.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgType = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgUrlAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgUrlAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph URL.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgUrlAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">URL value.</param>
     public OgUrlAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the URL.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgUrl = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgVideoAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgVideoAttribute.cs
@@ -1,17 +1,25 @@
 ﻿namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the Open Graph video URL.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgVideoAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Video URL.</param>
     public OgVideoAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the video URL.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.OgVideo = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/OgVideoAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/OgVideoAttribute.cs
@@ -1,4 +1,4 @@
-namespace AspNetSeo.CoreMvc;
+﻿namespace AspNetSeo.CoreMvc;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class OgVideoAttribute : SeoAttributeBase

--- a/src/AspNetSeo.CoreMvc/PageTitleAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/PageTitleAttribute.cs
@@ -1,14 +1,22 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the page title.
+/// </summary>
+/// <param name="value">Page title.</param>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class PageTitleAttribute(string value) : SeoAttributeBase
 {
     private readonly string _value = value;
 
+    /// <summary>Optional title format.</summary>
     public string? Format { get; set; }
 
+    /// <summary>Whether to clear the site name.</summary>
     public bool OverrideSiteName { get; set; }
 
+    /// <summary>Applies the page title.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.PageTitle = _value;
@@ -23,3 +31,4 @@ public class PageTitleAttribute(string value) : SeoAttributeBase
         }
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/SeoAttributeBase.cs
+++ b/src/AspNetSeo.CoreMvc/SeoAttributeBase.cs
@@ -1,9 +1,14 @@
-﻿using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Base attribute for setting SEO values.
+/// </summary>
 public abstract class SeoAttributeBase : ActionFilterAttribute
 {
+    /// <summary>Injects values before the action executes.</summary>
+    /// <param name="context">The action context.</param>
     public override void OnActionExecuting(ActionExecutingContext context)
     {
         if (context == null)
@@ -21,5 +26,8 @@ public abstract class SeoAttributeBase : ActionFilterAttribute
         OnHandleSeoValues(seoHelper);
     }
 
+    /// <summary>Applies values to the helper.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public abstract void OnHandleSeoValues(ISeoHelper seoHelper);
 }
+

--- a/src/AspNetSeo.CoreMvc/SeoController.cs
+++ b/src/AspNetSeo.CoreMvc/SeoController.cs
@@ -1,15 +1,21 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Base controller providing <see cref="ISeoHelper"/> access.
+/// </summary>
 public abstract class SeoController : Controller
 {
     private readonly Lazy<ISeoHelper> seoLazy;
 
+    /// <summary>Gets the SEO helper.</summary>
     public ISeoHelper Seo => seoLazy.Value;
 
+    /// <summary>Initializes the controller.</summary>
     protected SeoController()
     {
         seoLazy = new Lazy<ISeoHelper>(this.GetSeoHelper);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/ServiceCollectionExtensions.cs
+++ b/src/AspNetSeo.CoreMvc/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,8 +6,16 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Extensions for registering SEO services.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>Registers <see cref="ISeoHelper"/> and related services.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="siteName">Default site name.</param>
+    /// <param name="siteUrl">Default site URL.</param>
+    /// <param name="documentTitleFormat">Title format string.</param>
     public static void AddSeoHelper(
         this IServiceCollection services,
         string? siteName = null,
@@ -50,3 +58,4 @@ public static class ServiceCollectionExtensions
         });
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/ServiceProviderExtensions.cs
+++ b/src/AspNetSeo.CoreMvc/ServiceProviderExtensions.cs
@@ -1,9 +1,15 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Extensions for <see cref="IServiceProvider"/>.
+/// </summary>
 public static class ServiceProviderExtensions
 {
+    /// <summary>Gets a registered <see cref="ISeoHelper"/>.</summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <returns>The SEO helper.</returns>
     public static ISeoHelper GetSeoHelper(this IServiceProvider serviceProvider)
     {
         if (serviceProvider == null)
@@ -23,3 +29,4 @@ public static class ServiceProviderExtensions
         return seoHelper;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/SiteNameAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/SiteNameAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the default site name.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class SiteNameAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Site name.</param>
     public SiteNameAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the site name.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.SiteName = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/SiteUrlAttribute.cs
+++ b/src/AspNetSeo.CoreMvc/SiteUrlAttribute.cs
@@ -1,17 +1,25 @@
-﻿namespace AspNetSeo.CoreMvc;
+namespace AspNetSeo.CoreMvc;
 
+/// <summary>
+/// Sets the default site URL.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public class SiteUrlAttribute : SeoAttributeBase
 {
     private readonly string _value;
 
+    /// <summary>Initializes the attribute.</summary>
+    /// <param name="value">Site URL.</param>
     public SiteUrlAttribute(string value)
     {
         _value = value;
     }
 
+    /// <summary>Applies the site URL.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     public override void OnHandleSeoValues(ISeoHelper seoHelper)
     {
         seoHelper.SiteUrl = _value;
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/CustomMetasTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/CustomMetasTagHelper.cs
@@ -1,11 +1,18 @@
-﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders custom meta elements.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("custom-metas", TagStructure = TagStructure.NormalOrSelfClosing)]
 public class CustomMetasTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Builds the meta tags.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -49,3 +56,4 @@ public class CustomMetasTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHe
         output.Content.AppendHtml(tag);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/DocumentTitleTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/DocumentTitleTagHelper.cs
@@ -1,11 +1,18 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the document title element.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("document-title", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("title")]
 public class DocumentTitleTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Builds the title tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -25,3 +32,4 @@ public class DocumentTitleTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seo
         output.Content.SetHtmlContent(documentTitle);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/LinkCanonicalTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/LinkCanonicalTagHelper.cs
@@ -1,8 +1,14 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc;
+using AspNetSeo.CoreMvc.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the canonical link tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
+/// <param name="urlHelper">URL resolver.</param>
 [HtmlTargetElement("link-canonical", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("link")]
 public class LinkCanonicalTagHelper(
@@ -12,8 +18,12 @@ public class LinkCanonicalTagHelper(
     private readonly ISeoUrlHelper _urlHelper = urlHelper
             ?? throw new ArgumentNullException(nameof(urlHelper));
 
+    /// <summary>Canonical URL.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -43,3 +53,4 @@ public class LinkCanonicalTagHelper(
         output.Attributes.SetAttribute("href", linkCanonical);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/MetaDescriptionTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/MetaDescriptionTagHelper.cs
@@ -1,15 +1,23 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the meta description tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("meta-description", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class MetaDescriptionTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Value to override.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -21,3 +29,4 @@ public class MetaDescriptionTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(s
         output.ProcessMeta(MetaName.Description, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/MetaKeywordsTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/MetaKeywordsTagHelper.cs
@@ -1,15 +1,23 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the meta keywords tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("meta-keywords", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class MetaKeywordsTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Value to override.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -21,3 +29,4 @@ public class MetaKeywordsTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoH
         output.ProcessMeta(MetaName.Keywords, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/MetaRobotsTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/MetaRobotsTagHelper.cs
@@ -1,19 +1,29 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the meta robots tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("meta-robots", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class MetaRobotsTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Follow directive.</summary>
     public bool? Follow { get; set; }
 
+    /// <summary>Index directive.</summary>
     public bool? Index { get; set; }
 
+    /// <summary>Explicit value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -30,3 +40,4 @@ public class MetaRobotsTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHel
         output.ProcessMeta(MetaName.Robots, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgAudioTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgAudioTagHelper.cs
@@ -4,12 +4,20 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph audio tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-audio", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgAudioTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Audio URL.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -21,3 +29,4 @@ public class OgAudioTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper
         output.ProcessOpenGraph(OgMetaName.Audio, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgAudioTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgAudioTagHelper.cs
@@ -1,4 +1,4 @@
-using AspNetSeo.CoreMvc.Internal;
+﻿using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgDescriptionTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgDescriptionTagHelper.cs
@@ -1,15 +1,23 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph description tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-description", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgDescriptionTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Description value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -22,3 +30,4 @@ public class OgDescriptionTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seo
         output.ProcessOpenGraph(OgMetaName.Description, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgDeterminerTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgDeterminerTagHelper.cs
@@ -1,4 +1,4 @@
-using AspNetSeo.CoreMvc.Internal;
+﻿using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgDeterminerTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgDeterminerTagHelper.cs
@@ -4,12 +4,20 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph determiner tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-determiner", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgDeterminerTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Determiner value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -21,3 +29,4 @@ public class OgDeterminerTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoH
         output.ProcessOpenGraph(OgMetaName.Determiner, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgImageTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgImageTagHelper.cs
@@ -1,15 +1,23 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph image tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-image", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgImageTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Image URL.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -21,3 +29,4 @@ public class OgImageTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper
         output.ProcessOpenGraph(OgMetaName.Image, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleAlternateTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleAlternateTagHelper.cs
@@ -1,14 +1,22 @@
-﻿using AspNetSeo.Internal;
+using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders Open Graph locale alternates.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-locale-alternate", TagStructure = TagStructure.NormalOrSelfClosing)]
 public class OgLocaleAlternateTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Optional locale value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tags.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         var values = Value != null
@@ -55,3 +63,4 @@ public class OgLocaleAlternateTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase
         }
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleTagHelper.cs
@@ -4,12 +4,20 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph locale tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-locale", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgLocaleTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Locale value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -21,3 +29,4 @@ public class OgLocaleTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelpe
         output.ProcessOpenGraph(OgMetaName.Locale, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgLocaleTagHelper.cs
@@ -1,4 +1,4 @@
-using AspNetSeo.CoreMvc.Internal;
+﻿using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgSiteNameTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgSiteNameTagHelper.cs
@@ -1,15 +1,23 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph site name tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-site-name", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgSiteNameTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Site name value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -22,3 +30,4 @@ public class OgSiteNameTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHel
         output.ProcessOpenGraph(OgMetaName.SiteName, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgTitleTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgTitleTagHelper.cs
@@ -1,17 +1,26 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph title tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement(Tag, TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgTitleTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Element tag name.</summary>
     public const string Tag = "og-title";
 
+    /// <summary>Title value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -24,3 +33,4 @@ public class OgTitleTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper
         output.ProcessOpenGraph(OgMetaName.Title, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgTypeTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgTypeTagHelper.cs
@@ -1,15 +1,23 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph type tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-type", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgTypeTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Type value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -21,3 +29,4 @@ public class OgTypeTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
         output.ProcessOpenGraph(OgMetaName.Type, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgUrlTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgUrlTagHelper.cs
@@ -1,9 +1,15 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+using AspNetSeo.CoreMvc;
+using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph URL tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
+/// <param name="urlHelper">URL resolver.</param>
 [HtmlTargetElement("og-url", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgUrlTagHelper(
@@ -13,8 +19,12 @@ public class OgUrlTagHelper(
     private readonly ISeoUrlHelper _urlHelper = urlHelper
             ?? throw new ArgumentNullException(nameof(urlHelper));
 
+    /// <summary>URL value.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -33,3 +43,4 @@ public class OgUrlTagHelper(
         output.ProcessOpenGraph(OgMetaName.Url, linkCanonical);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgVideoTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgVideoTagHelper.cs
@@ -4,12 +4,20 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Renders the Open Graph video tag.
+/// </summary>
+/// <param name="seoHelper">The SEO helper.</param>
 [HtmlTargetElement("og-video", TagStructure = TagStructure.WithoutEndTag)]
 [OutputElementHint("meta")]
 public class OgVideoTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper)
 {
+    /// <summary>Video URL.</summary>
     public string? Value { get; set; }
 
+    /// <summary>Builds the tag.</summary>
+    /// <param name="context">Tag helper context.</param>
+    /// <param name="output">Tag helper output.</param>
     public override void Process(
         TagHelperContext context,
         TagHelperOutput output)
@@ -21,3 +29,4 @@ public class OgVideoTagHelper(ISeoHelper seoHelper) : SeoTagHelperBase(seoHelper
         output.ProcessOpenGraph(OgMetaName.Video, content);
     }
 }
+

--- a/src/AspNetSeo.CoreMvc/TagHelpers/OgVideoTagHelper.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/OgVideoTagHelper.cs
@@ -1,4 +1,4 @@
-using AspNetSeo.CoreMvc.Internal;
+﻿using AspNetSeo.CoreMvc.Internal;
 using AspNetSeo.Internal;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 

--- a/src/AspNetSeo.CoreMvc/TagHelpers/SeoTagHelperBase.cs
+++ b/src/AspNetSeo.CoreMvc/TagHelpers/SeoTagHelperBase.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace AspNetSeo.CoreMvc.TagHelpers;
 
+/// <summary>
+/// Base tag helper with access to <see cref="ISeoHelper"/>.
+/// </summary>
 public abstract class SeoTagHelperBase : TagHelper
 {
+    /// <summary>The SEO helper instance.</summary>
     protected readonly ISeoHelper SeoHelper;
 
+    /// <summary>Initializes the helper.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
     protected SeoTagHelperBase(ISeoHelper seoHelper)
     {
         SeoHelper = seoHelper
             ?? throw new ArgumentNullException(nameof(seoHelper));
     }
 }
+

--- a/src/AspNetSeo/ISeoHelper.cs
+++ b/src/AspNetSeo/ISeoHelper.cs
@@ -1,50 +1,78 @@
-﻿namespace AspNetSeo;
+namespace AspNetSeo;
 
+/// <summary>
+/// Describes SEO-related values.
+/// </summary>
 public interface ISeoHelper
 {
+    /// <summary>Custom meta tags.</summary>
     IDictionary<string, string?> CustomMetas { get; }
 
+    /// <summary>Computed document title.</summary>
     string? DocumentTitle { get; }
 
+    /// <summary>Title format pattern.</summary>
     string? DocumentTitleFormat { get; set; }
 
+    /// <summary>Canonical link.</summary>
     string? LinkCanonical { get; set; }
 
+    /// <summary>Meta description.</summary>
     string? MetaDescription { get; set; }
 
+    /// <summary>Meta keywords.</summary>
     string? MetaKeywords { get; set; }
 
+    /// <summary>Meta robots value.</summary>
     string? MetaRobots { get; set; }
 
+    /// <summary>Open Graph audio.</summary>
     string? OgAudio { get; set; }
 
+    /// <summary>Open Graph description.</summary>
     string? OgDescription { get; set; }
 
+    /// <summary>Open Graph determiner.</summary>
     string? OgDeterminer { get; set; }
 
+    /// <summary>Open Graph image.</summary>
     string? OgImage { get; set; }
 
+    /// <summary>Open Graph locale.</summary>
     string? OgLocale { get; set; }
 
+    /// <summary>Alternate locales.</summary>
     IList<string> OgLocaleAlternates { get; }
 
+    /// <summary>Open Graph site name.</summary>
     string? OgSiteName { get; set; }
 
+    /// <summary>Open Graph title.</summary>
     string? OgTitle { get; set; }
 
+    /// <summary>Open Graph type.</summary>
     string? OgType { get; set; }
 
+    /// <summary>Open Graph URL.</summary>
     string? OgUrl { get; set; }
 
+    /// <summary>Open Graph video.</summary>
     string? OgVideo { get; set; }
 
+    /// <summary>Page title.</summary>
     string? PageTitle { get; set; }
 
+    /// <summary>Site name.</summary>
     string? SiteName { get; set; }
 
+    /// <summary>Site URL.</summary>
     string? SiteUrl { get; set; }
 
+    /// <summary>Sets a custom meta tag.</summary>
     void SetCustomMeta(string key, string? value);
 
+    /// <summary>Creates a robots value.</summary>
+    /// <returns>The meta robots string.</returns>
     string SetMetaRobots(bool index, bool follow);
 }
+

--- a/src/AspNetSeo/ISeoHelper.cs
+++ b/src/AspNetSeo/ISeoHelper.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace AspNetSeo;
+﻿namespace AspNetSeo;
 
 public interface ISeoHelper
 {

--- a/src/AspNetSeo/SeoHelper.cs
+++ b/src/AspNetSeo/SeoHelper.cs
@@ -1,5 +1,4 @@
 ﻿using AspNetSeo.Internal;
-using System.Collections.Generic;
 
 namespace AspNetSeo;
 

--- a/src/AspNetSeo/SeoHelper.cs
+++ b/src/AspNetSeo/SeoHelper.cs
@@ -1,55 +1,82 @@
-﻿using AspNetSeo.Internal;
+using AspNetSeo.Internal;
 
 namespace AspNetSeo;
 
+/// <summary>
+/// Concrete implementation of <see cref="ISeoHelper"/>.
+/// </summary>
 public class SeoHelper : ISeoHelper
 {
     internal const string? DefaultDocumentTitleFormat = "{0} - {1}";
 
+    /// <summary>Custom meta tags.</summary>
     public IDictionary<string, string?> CustomMetas { get; }
         = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Calculated document title.</summary>
     public string? DocumentTitle => DocumentTitleValue.Get(this);
 
+    /// <summary>Format pattern for the title.</summary>
     public string? DocumentTitleFormat { get; set; }
         = DefaultDocumentTitleFormat;
 
+    /// <summary>Canonical link.</summary>
     public string? LinkCanonical { get; set; }
 
+    /// <summary>Meta description.</summary>
     public string? MetaDescription { get; set; }
 
+    /// <summary>Meta keywords.</summary>
     public string? MetaKeywords { get; set; }
 
+    /// <summary>Meta robots value.</summary>
     public string? MetaRobots { get; set; }
 
+    /// <summary>Open Graph audio.</summary>
     public string? OgAudio { get; set; }
 
+    /// <summary>Open Graph description.</summary>
     public string? OgDescription { get; set; }
 
+    /// <summary>Open Graph determiner.</summary>
     public string? OgDeterminer { get; set; }
 
+    /// <summary>Open Graph image.</summary>
     public string? OgImage { get; set; }
 
+    /// <summary>Open Graph locale.</summary>
     public string? OgLocale { get; set; }
 
+    /// <summary>Alternate locales.</summary>
     public IList<string> OgLocaleAlternates { get; } = new List<string>();
 
+    /// <summary>Open Graph site name.</summary>
     public string? OgSiteName { get; set; }
 
+    /// <summary>Open Graph title.</summary>
     public string? OgTitle { get; set; }
 
+    /// <summary>Open Graph type.</summary>
     public string? OgType { get; set; }
 
+    /// <summary>Open Graph URL.</summary>
     public string? OgUrl { get; set; }
 
+    /// <summary>Open Graph video.</summary>
     public string? OgVideo { get; set; }
 
+    /// <summary>Page title.</summary>
     public string? PageTitle { get; set; }
 
+    /// <summary>Site name.</summary>
     public string? SiteName { get; set; }
 
+    /// <summary>Site URL.</summary>
     public string? SiteUrl { get; set; }
 
+    /// <summary>Stores a custom meta tag.</summary>
+    /// <param name="key">Meta name.</param>
+    /// <param name="value">Meta value.</param>
     public void SetCustomMeta(string? key, string? value)
     {
         if (key == null)
@@ -58,6 +85,10 @@ public class SeoHelper : ISeoHelper
         CustomMetas[key] = value;
     }
 
+    /// <summary>Sets the robots directive.</summary>
+    /// <param name="index">Whether indexing is allowed.</param>
+    /// <param name="follow">Whether following is allowed.</param>
+    /// <returns>The robots string.</returns>
     public string SetMetaRobots(bool index, bool follow)
     {
         MetaRobots = MetaRobotsValue.Get(index, follow);
@@ -65,3 +96,4 @@ public class SeoHelper : ISeoHelper
         return MetaRobots;
     }
 }
+

--- a/src/AspNetSeo/SeoHelperExtensions.cs
+++ b/src/AspNetSeo/SeoHelperExtensions.cs
@@ -1,9 +1,16 @@
-﻿namespace AspNetSeo;
+namespace AspNetSeo;
 
+/// <summary>
+/// Helper extensions for SEO values.
+/// </summary>
 public static class SeoHelperExtensions
 {
     private const string DefaultSeparator = ", ";
 
+    /// <summary>Adds meta keywords.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
+    /// <param name="keywords">Keywords to add.</param>
+    /// <returns>Combined keywords.</returns>
     public static string? AddMetaKeywords(
         this ISeoHelper seoHelper,
         params string[] keywords)
@@ -16,6 +23,11 @@ public static class SeoHelperExtensions
         return seoHelper.AddMetaKeywordsWithSeparator(DefaultSeparator, keywords);
     }
 
+    /// <summary>Adds meta keywords with a separator.</summary>
+    /// <param name="seoHelper">The SEO helper.</param>
+    /// <param name="separator">Separator string.</param>
+    /// <param name="keywords">Keywords to add.</param>
+    /// <returns>Combined keywords.</returns>
     public static string? AddMetaKeywordsWithSeparator(
         this ISeoHelper seoHelper,
         string separator,
@@ -60,3 +72,4 @@ public static class SeoHelperExtensions
         return string.Join(separator, cleanedValues).Trim();
     }
 }
+

--- a/test/AspNetSeo.CoreMvc.Tests/TagAttributeTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagAttributeTest.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Xunit;
 
 namespace AspNetSeo.CoreMvc.Tests;

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgAudioTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgAudioTagHelperTest.cs
@@ -1,4 +1,4 @@
-using AspNetSeo.CoreMvc.TagHelpers;
+﻿using AspNetSeo.CoreMvc.TagHelpers;
 using AspNetSeo.Internal;
 using AspNetSeo.Testing;
 using Microsoft.AspNetCore.Razor.TagHelpers;

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgDeterminerTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgDeterminerTagHelperTest.cs
@@ -1,4 +1,4 @@
-using AspNetSeo.CoreMvc.TagHelpers;
+﻿using AspNetSeo.CoreMvc.TagHelpers;
 using AspNetSeo.Internal;
 using AspNetSeo.Testing;
 using Microsoft.AspNetCore.Razor.TagHelpers;

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgLocaleTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgLocaleTagHelperTest.cs
@@ -1,4 +1,4 @@
-using AspNetSeo.CoreMvc.TagHelpers;
+﻿using AspNetSeo.CoreMvc.TagHelpers;
 using AspNetSeo.Internal;
 using AspNetSeo.Testing;
 using Microsoft.AspNetCore.Razor.TagHelpers;

--- a/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgVideoTagHelperTest.cs
+++ b/test/AspNetSeo.CoreMvc.Tests/TagHelpers/OgVideoTagHelperTest.cs
@@ -1,4 +1,4 @@
-using AspNetSeo.CoreMvc.TagHelpers;
+﻿using AspNetSeo.CoreMvc.TagHelpers;
 using AspNetSeo.Internal;
 using AspNetSeo.Testing;
 using Microsoft.AspNetCore.Razor.TagHelpers;

--- a/test/AspNetSeo.Testing/SeoUrlHelperTestFactory.cs
+++ b/test/AspNetSeo.Testing/SeoUrlHelperTestFactory.cs
@@ -1,4 +1,5 @@
-﻿using AspNetSeo.CoreMvc.Internal;
+﻿using AspNetSeo.CoreMvc;
+using AspNetSeo.CoreMvc.Internal;
 using Microsoft.AspNetCore.Mvc.Routing;
 
 namespace AspNetSeo.Testing;


### PR DESCRIPTION
## Summary
- document SEO helper interface and implementation
- add XML docs to MVC SEO attributes and tag helpers
- document service and controller extension helpers
- move `ISeoUrlHelper` to the public `AspNetSeo.CoreMvc` namespace

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab05baa1d88323a4aba61924c55c2f